### PR TITLE
print percent support for all level

### DIFF
--- a/topdown/draw_new.py
+++ b/topdown/draw_new.py
@@ -63,7 +63,7 @@ def calculate_percentages(df):
     df = preprocess_for_percentage(df)
     
     # 获取所有列的总和作为基准
-    total = df['base'] + df['Frontend'].fillna(0) + df['Backend'].fillna(0) + df['BadSpec'].fillna(0)
+    total = df.fillna(0).sum(axis=1)
     
     # 计算每列的百分比
     percentages = pd.DataFrame()

--- a/topdown/topdown_stat_map.py
+++ b/topdown/topdown_stat_map.py
@@ -275,11 +275,13 @@ def mergeBadSpecInst(df):
 
 def rename_with_map(df: pd.DataFrame, hierarchy, level):
     mergeBadSpecInst(df)
+    to_drops = ['Cycles', 'Insts', 'coverage']
     if level == 3:
         # 当 level=3 时，我们不进行任何重命名或合并
+        print(f'level3 dropping {to_drops}')
+        df.drop(columns=to_drops, inplace=True)
         return
     rename_map = create_rename_map(hierarchy, level)
-    to_drops = []
     columns_to_keep = ['cpi', 'point', 'bmk', 'workload']
 
     for col in df.columns:


### PR DESCRIPTION
This PR enables the `-p` option in `draw_new.py` to support percentage output for all levels. Although at higher levels (e.g., level=3), the percentage differences in stalls between certain tags may not be significant, adding this support allows for percentage analysis of other options where the differences are more noticeable.

@jensen-yan 